### PR TITLE
Auto-fetch latest runner version if VERSION arg not provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$TARGETPLATFORM ubuntu:22.04
 
 ARG TARGETARCH
 ARG OS=linux
-ARG VERSION=2.324.0
+ARG VERSION
 
 RUN apt update && apt install -y curl wget sudo git jq ca-certificates gnupg lsb-release && \
     mkdir -p /etc/apt/keyrings && \
@@ -17,7 +17,11 @@ RUN useradd -G sudo,docker -ms /bin/bash github && \
 USER github
 WORKDIR /home/github/actions
 
-RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+RUN if [ -z "${VERSION}" ]; then \
+        VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | sed 's/^v//') ; \
+        echo "Fetched latest version: ${VERSION}" ; \
+    fi ; \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
         curl -o actions-runner-${OS}.tar.gz -fsSL https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-${OS}-x64-${VERSION}.tar.gz ; \
     fi ; \
     if [ "${TARGETARCH}" = "arm64" ]; then \


### PR DESCRIPTION
## Summary
- Update Dockerfile to automatically fetch the latest GitHub Actions runner version from the API when VERSION build arg is not specified
- Maintains backward compatibility by allowing manual version override via build arg
- Ensures images use the latest runner by default without requiring manual version updates

## Test plan
- [ ] Build without VERSION arg: `docker build -t test-runner .`
- [ ] Verify it fetches and uses the latest version
- [ ] Build with VERSION arg: `docker build --build-arg VERSION=2.324.0 -t test-runner .`
- [ ] Verify it uses the specified version

🤖 Generated with [Claude Code](https://claude.ai/code)