### PR TITLE
Clear /tmp during cleanup to bound writable layer growth

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,9 @@ cleanup() {
     echo "Removing runner..."
     ./config.sh remove --token $REG_TOKEN
     rm -rf ./_work/*
+    # /tmp is not under _work but many tools (buildx, setup-*, pip/npm, mktemp) write here.
+    # Without this, /tmp grows unbounded across container restarts since the writable layer persists.
+    sudo rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null || true
     if [ -n ${DOCKER_SYSBOX_RUNTIME} ]; then
         sudo pkill --pidfile /home/github/dockerd.pid
     fi


### PR DESCRIPTION
## Summary

`cleanup()` in `start.sh` only wipes `./_work/*`, never `/tmp`. Because GitHub Actions tooling (buildx scratch, `setup-*` tool downloads, pip/npm temp, plain `mktemp -d`) routinely writes to `/tmp`, the writable layer grows unbounded on long-lived instances.

The runner is started with `--ephemeral`, so naively you'd expect each job to leave a fresh filesystem. But the example compose files use `restart: always`, which restarts the **same** container after each job rather than recreating it — the writable layer (and `/tmp` with it) persists. Meanwhile `docker system prune` cannot reclaim a running container's writable layer, so the disk leak is invisible to the usual cleanup tooling.

Observed on a real instance: `/var/lib/containerd` reached ~539 GB, with `du -h -d1 /` inside the container reporting **413 GB in `/tmp`** after ~8 months of uptime.

## Fix

Wipe `/tmp` in `cleanup()` alongside `_work`. `sudo` is needed because some jobs write as root via container actions; failures are swallowed with `|| true` so a partial-permission case can't block the trap.

```diff
     rm -rf ./_work/*
+    # /tmp is not under _work but many tools (buildx, setup-*, pip/npm, mktemp) write here.
+    # Without this, /tmp grows unbounded across container restarts since the writable layer persists.
+    sudo rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null || true
```

## Alternative considered

Mounting `tmpfs: /tmp` in each compose file would also solve it and even cap RAM use, but it changes semantics for users with large builds that exceed available RAM, so I left it out of this PR. Happy to do that as a follow-up if you'd prefer it.

## Test plan

- [ ] On an instance experiencing the leak, deploy this image, let a few jobs run, and confirm `/tmp` returns to near-empty after each.
- [ ] Sanity-check that a buildx job still completes (i.e. `/tmp` cleanup happens *after* the job, not during).

🤖 Generated with [Claude Code](https://claude.com/claude-code)